### PR TITLE
#473 No columns shown when opening a log4j xml file

### DIFF
--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/api/gui/LogViewPanelWrapper.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/api/gui/LogViewPanelWrapper.java
@@ -87,14 +87,13 @@ public class LogViewPanelWrapper extends JPanel {
         closing();
       }
     });
-    final TableColumns[] columns = (visibleColumns == null) ? TableColumns.ALL_WITHOUT_LOG_SOURCE : visibleColumns;
 
     fillDefaultConfiguration();
 
     SoftReference<Stoppable> stoppableReference = new SoftReference<>(stoppable);
     // this.statusObserver = statusObserver;
     dataTableModel = logDataTableModel == null ? new LogDataTableModel() : logDataTableModel;
-    logViewPanel = new LogViewPanel(dataTableModel, columns, otrosApplication);
+    logViewPanel = new LogViewPanel(dataTableModel, visibleColumns, otrosApplication);
 
     cardLayout = new CardLayout();
     GridBagConstraints c = new GridBagConstraints();
@@ -142,10 +141,12 @@ public class LogViewPanelWrapper extends JPanel {
   }
 
 
+  @Override
   public String getName() {
     return name;
   }
 
+  @Override
   public void setName(String name) {
     this.name = name;
   }

--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/api/importer/LogImporter.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/api/importer/LogImporter.java
@@ -18,13 +18,14 @@ package pl.otros.logview.api.importer;
 import pl.otros.logview.api.InitializationException;
 import pl.otros.logview.api.model.LogDataCollector;
 import pl.otros.logview.api.parser.ParsingContext;
+import pl.otros.logview.api.parser.TableColumnNameSelfDescribable;
 import pl.otros.logview.api.pluginable.PluginableElement;
 
 import javax.swing.*;
 import java.io.InputStream;
 import java.util.Properties;
 
-public interface LogImporter extends PluginableElement {
+public interface LogImporter extends PluginableElement, TableColumnNameSelfDescribable {
 
   int LOG_IMPORTER_VERSION_1 = 1;
 

--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/api/importer/LogImporterUsingParser.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/api/importer/LogImporterUsingParser.java
@@ -30,7 +30,7 @@ import java.nio.charset.Charset;
 import java.text.ParseException;
 import java.util.Properties;
 
-public class LogImporterUsingParser implements LogImporter, TableColumnNameSelfDescribable {
+public class LogImporterUsingParser implements LogImporter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(LogImporterUsingParser.class.getName());
   private LogParser parser = null;
@@ -170,12 +170,7 @@ public class LogImporterUsingParser implements LogImporter, TableColumnNameSelfD
 
   @Override
   public TableColumns[] getTableColumnsToUse() {
-    TableColumns[] columns = TableColumns.ALL_WITHOUT_LOG_SOURCE;
-    if (parser instanceof TableColumnNameSelfDescribable) {
-      TableColumnNameSelfDescribable descriable = (TableColumnNameSelfDescribable) parser;
-      columns = descriable.getTableColumnsToUse();
-    }
-    return columns;
+    return parser.getTableColumnsToUse();
   }
 
   @Override

--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/api/parser/LogParser.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/api/parser/LogParser.java
@@ -21,7 +21,7 @@ import pl.otros.logview.api.model.LogData;
 import java.text.ParseException;
 import java.util.Properties;
 
-public interface LogParser {
+public interface LogParser extends TableColumnNameSelfDescribable {
 
   int LOG_PARSER_VERSION_1 = 1;
 

--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/gui/actions/TailLogActionListener.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/gui/actions/TailLogActionListener.java
@@ -32,7 +32,6 @@ import pl.otros.logview.api.loading.LogLoader;
 import pl.otros.logview.api.loading.LogLoadingSession;
 import pl.otros.logview.api.loading.VfsSource;
 import pl.otros.logview.api.parser.ParsingContext;
-import pl.otros.logview.api.parser.TableColumnNameSelfDescribable;
 import pl.otros.vfs.browser.JOtrosVfsBrowserDialog;
 import pl.otros.vfs.browser.SelectionMode;
 
@@ -56,6 +55,7 @@ public class TailLogActionListener extends OtrosAction {
     this.importer = importer;
   }
 
+  @Override
   public void actionPerformed(ActionEvent e) {
     JOtrosVfsBrowserDialog chooser = getOtrosApplication().getOtrosVfsBrowserDialog();
     initFileChooser(chooser);
@@ -104,12 +104,7 @@ public class TailLogActionListener extends OtrosAction {
   }
 
   protected TableColumns[] determineTableColumnsToUse(LoadingInfo loadingInfo, LogImporter importer) {
-    TableColumns[] tableColumnsToUse = TableColumns.ALL_WITHOUT_LOG_SOURCE;
-    if (importer instanceof TableColumnNameSelfDescribable) {
-      TableColumnNameSelfDescribable describable = (TableColumnNameSelfDescribable) importer;
-      tableColumnsToUse = describable.getTableColumnsToUse();
-    }
-    return tableColumnsToUse;
+    return importer.getTableColumnsToUse();
   }
 
 

--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/gui/actions/read/LogFileInNewTabOpener.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/gui/actions/read/LogFileInNewTabOpener.java
@@ -19,13 +19,11 @@ import org.apache.commons.vfs2.FileObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.otros.logview.api.OtrosApplication;
-import pl.otros.logview.api.TableColumns;
 import pl.otros.logview.api.gui.Icons;
 import pl.otros.logview.api.gui.LogViewPanelWrapper;
 import pl.otros.logview.api.importer.LogImporter;
 import pl.otros.logview.api.io.LoadingInfo;
 import pl.otros.logview.api.io.Utils;
-import pl.otros.logview.api.parser.TableColumnNameSelfDescribable;
 
 import javax.swing.*;
 
@@ -69,16 +67,10 @@ public class LogFileInNewTabOpener {
   }
 
   private LogViewPanelWrapper createPanelForLog(FileObject file, final LoadingInfo openFileObject, LogImporter importer) {
-    TableColumns[] tableColumnsToUse = TableColumns.ALL_WITHOUT_LOG_SOURCE;
-    if (importer instanceof TableColumnNameSelfDescribable) {
-      TableColumnNameSelfDescribable describable = (TableColumnNameSelfDescribable) importer;
-      tableColumnsToUse = describable.getTableColumnsToUse();
-    }
-
     return new LogViewPanelWrapper(
       file.getName().getBaseName(),
       openFileObject.getObserableInputStreamImpl(),
-      tableColumnsToUse, otrosApplication);
+      importer.getTableColumnsToUse(), otrosApplication);
   }
 
 

--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/gui/open/AdvanceOpenPanel.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/gui/open/AdvanceOpenPanel.java
@@ -24,7 +24,6 @@ import pl.otros.logview.api.loading.LogLoader;
 import pl.otros.logview.api.loading.LogLoadingSession;
 import pl.otros.logview.api.loading.VfsSource;
 import pl.otros.logview.api.model.LogDataCollector;
-import pl.otros.logview.api.parser.TableColumnNameSelfDescribable;
 import pl.otros.logview.api.pluginable.PluginableElement;
 import pl.otros.logview.api.services.PersistService;
 import pl.otros.logview.gui.GuiUtils;
@@ -652,9 +651,6 @@ public class AdvanceOpenPanel extends JPanel {
     return logImporters.stream()
       .filter(Optional::isPresent)
       .map(Optional::get)
-      .filter(l -> !(l instanceof DetectOnTheFlyLogImporter))
-      .filter(l -> l instanceof TableColumnNameSelfDescribable)
-      .map(l -> (TableColumnNameSelfDescribable) l)
       .flatMap(l -> Arrays.stream(l.getTableColumnsToUse()))
       .distinct()
       .toArray(TableColumns[]::new);

--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/importer/DetectOnTheFlyLogImporter.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/importer/DetectOnTheFlyLogImporter.java
@@ -19,6 +19,7 @@ package pl.otros.logview.importer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.otros.logview.api.InitializationException;
+import pl.otros.logview.api.TableColumns;
 import pl.otros.logview.api.importer.LogImporter;
 import pl.otros.logview.api.io.Utils;
 import pl.otros.logview.api.model.LogDataCollector;
@@ -31,6 +32,21 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Optional;
 import java.util.Properties;
+
+import static pl.otros.logview.api.TableColumns.CLASS;
+import static pl.otros.logview.api.TableColumns.FILE;
+import static pl.otros.logview.api.TableColumns.ID;
+import static pl.otros.logview.api.TableColumns.LEVEL;
+import static pl.otros.logview.api.TableColumns.LINE;
+import static pl.otros.logview.api.TableColumns.LOGGER_NAME;
+import static pl.otros.logview.api.TableColumns.LOG_SOURCE;
+import static pl.otros.logview.api.TableColumns.MARK;
+import static pl.otros.logview.api.TableColumns.MESSAGE;
+import static pl.otros.logview.api.TableColumns.METHOD;
+import static pl.otros.logview.api.TableColumns.NDC;
+import static pl.otros.logview.api.TableColumns.PROPERTIES;
+import static pl.otros.logview.api.TableColumns.THREAD;
+import static pl.otros.logview.api.TableColumns.TIME;
 
 public class DetectOnTheFlyLogImporter extends AbstractPluginableElement implements LogImporter {
 
@@ -115,6 +131,12 @@ public class DetectOnTheFlyLogImporter extends AbstractPluginableElement impleme
       }
 
     }
+  }
+
+  @Override
+  public TableColumns[] getTableColumnsToUse() {
+    return new TableColumns[] { ID, TIME, LEVEL, MESSAGE, CLASS, METHOD, THREAD, MARK, FILE, LINE, NDC, PROPERTIES, LOGGER_NAME,
+        LOG_SOURCE };
   }
 
   @Override

--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/importer/Log4jSerilizedLogImporter.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/importer/Log4jSerilizedLogImporter.java
@@ -21,6 +21,7 @@ import org.apache.log4j.spi.LoggingEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.otros.logview.api.InitializationException;
+import pl.otros.logview.api.TableColumns;
 import pl.otros.logview.api.importer.LogImporter;
 import pl.otros.logview.api.model.LogData;
 import pl.otros.logview.api.model.LogDataCollector;
@@ -34,6 +35,20 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.util.Properties;
+
+import static pl.otros.logview.api.TableColumns.CLASS;
+import static pl.otros.logview.api.TableColumns.FILE;
+import static pl.otros.logview.api.TableColumns.ID;
+import static pl.otros.logview.api.TableColumns.LEVEL;
+import static pl.otros.logview.api.TableColumns.LINE;
+import static pl.otros.logview.api.TableColumns.LOGGER_NAME;
+import static pl.otros.logview.api.TableColumns.LOG_SOURCE;
+import static pl.otros.logview.api.TableColumns.MESSAGE;
+import static pl.otros.logview.api.TableColumns.METHOD;
+import static pl.otros.logview.api.TableColumns.NDC;
+import static pl.otros.logview.api.TableColumns.PROPERTIES;
+import static pl.otros.logview.api.TableColumns.THREAD;
+import static pl.otros.logview.api.TableColumns.TIME;
 
 public class Log4jSerilizedLogImporter extends AbstractPluginableElement implements LogImporter {
 
@@ -77,6 +92,11 @@ public class Log4jSerilizedLogImporter extends AbstractPluginableElement impleme
     } finally {
       IOUtils.closeQuietly(in);
     }
+  }
+
+  @Override
+  public TableColumns[] getTableColumnsToUse() {
+    return new TableColumns[] { ID, TIME, MESSAGE, LEVEL, CLASS, METHOD, FILE, LINE, NDC, THREAD, LOGGER_NAME, PROPERTIES, LOG_SOURCE };
   }
 
   @Override

--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/importer/UtilLoggingXmlLogImporter.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/importer/UtilLoggingXmlLogImporter.java
@@ -29,7 +29,6 @@ import pl.otros.logview.api.importer.LogImporter;
 import pl.otros.logview.api.model.LogData;
 import pl.otros.logview.api.model.LogDataCollector;
 import pl.otros.logview.api.parser.ParsingContext;
-import pl.otros.logview.api.parser.TableColumnNameSelfDescribable;
 import pl.otros.logview.importer.log4jxml.SAXErrorHandler;
 import pl.otros.logview.importer.log4jxml.UtilLoggingEntityResolver;
 import pl.otros.logview.pluginable.AbstractPluginableElement;
@@ -45,7 +44,7 @@ import java.util.Date;
 import java.util.Properties;
 import java.util.logging.Level;
 
-public class UtilLoggingXmlLogImporter extends AbstractPluginableElement implements LogImporter, TableColumnNameSelfDescribable {
+public class UtilLoggingXmlLogImporter extends AbstractPluginableElement implements LogImporter {
 
   private static final String DOC_BUILDER = "DOC_BUILDER";
   private static final String PARTIAL_EVENT = "PARTIAL_EVENT";

--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/importer/log4jxml/Log4jXmlLogImporter.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/importer/log4jxml/Log4jXmlLogImporter.java
@@ -17,6 +17,7 @@ package pl.otros.logview.importer.log4jxml;
 
 import org.apache.log4j.spi.LoggingEvent;
 import pl.otros.logview.api.InitializationException;
+import pl.otros.logview.api.TableColumns;
 import pl.otros.logview.api.importer.LogImporter;
 import pl.otros.logview.api.model.LogData;
 import pl.otros.logview.api.model.LogDataCollector;
@@ -24,16 +25,28 @@ import pl.otros.logview.api.parser.ParsingContext;
 import pl.otros.logview.parser.log4j.Log4jUtil;
 import pl.otros.logview.pluginable.AbstractPluginableElement;
 
-import javax.swing.*;
+import javax.swing.Icon;
+
 import java.io.InputStream;
 import java.util.Properties;
 import java.util.Vector;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static pl.otros.logview.api.TableColumns.CLASS;
+import static pl.otros.logview.api.TableColumns.FILE;
+import static pl.otros.logview.api.TableColumns.ID;
+import static pl.otros.logview.api.TableColumns.LEVEL;
+import static pl.otros.logview.api.TableColumns.LINE;
+import static pl.otros.logview.api.TableColumns.LOGGER_NAME;
+import static pl.otros.logview.api.TableColumns.LOG_SOURCE;
+import static pl.otros.logview.api.TableColumns.MESSAGE;
+import static pl.otros.logview.api.TableColumns.METHOD;
+import static pl.otros.logview.api.TableColumns.NDC;
+import static pl.otros.logview.api.TableColumns.PROPERTIES;
+import static pl.otros.logview.api.TableColumns.THREAD;
+import static pl.otros.logview.api.TableColumns.TIME;
 
-public class Log4jXmlLogImporter extends AbstractPluginableElement implements
-  LogImporter {
-
+public class Log4jXmlLogImporter extends AbstractPluginableElement implements LogImporter {
   private static final int DEFAULT_PARSE_BUFFER_SIZE = 16 * 1024;
   private static final String LOG4J_XML_LOG_IMPORTER_DECODER = "Log4jXmlLogImporter.decoder";
 
@@ -74,6 +87,11 @@ public class Log4jXmlLogImporter extends AbstractPluginableElement implements
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  @Override
+  public TableColumns[] getTableColumnsToUse() {
+    return new TableColumns[] { ID, TIME, MESSAGE, LEVEL, CLASS, METHOD, FILE, LINE, NDC, THREAD, LOGGER_NAME, PROPERTIES, LOG_SOURCE };
   }
 
   @Override

--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/importer/logback/LogbackSocketLogImporter.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/importer/logback/LogbackSocketLogImporter.java
@@ -4,17 +4,31 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.otros.logview.api.InitializationException;
+import pl.otros.logview.api.TableColumns;
 import pl.otros.logview.api.importer.LogImporter;
 import pl.otros.logview.api.model.LogDataBuilder;
 import pl.otros.logview.api.model.LogDataCollector;
 import pl.otros.logview.api.parser.ParsingContext;
 import pl.otros.logview.pluginable.AbstractPluginableElement;
 
-import javax.swing.*;
+import javax.swing.Icon;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.util.Properties;
+
+import static pl.otros.logview.api.TableColumns.CLASS;
+import static pl.otros.logview.api.TableColumns.ID;
+import static pl.otros.logview.api.TableColumns.LEVEL;
+import static pl.otros.logview.api.TableColumns.LINE;
+import static pl.otros.logview.api.TableColumns.LOGGER_NAME;
+import static pl.otros.logview.api.TableColumns.MARK;
+import static pl.otros.logview.api.TableColumns.MESSAGE;
+import static pl.otros.logview.api.TableColumns.METHOD;
+import static pl.otros.logview.api.TableColumns.PROPERTIES;
+import static pl.otros.logview.api.TableColumns.THREAD;
+import static pl.otros.logview.api.TableColumns.TIME;
 
 public class LogbackSocketLogImporter extends AbstractPluginableElement implements LogImporter {
   private static final Logger LOGGER = LoggerFactory.getLogger(LogbackSocketLogImporter.class.getName());
@@ -35,8 +49,6 @@ public class LogbackSocketLogImporter extends AbstractPluginableElement implemen
 
   @Override
   public void initParsingContext(ParsingContext parsingContext) {
-
-
   }
 
   @Override
@@ -58,6 +70,10 @@ public class LogbackSocketLogImporter extends AbstractPluginableElement implemen
     }
   }
 
+  @Override
+  public TableColumns[] getTableColumnsToUse() {
+    return new TableColumns[] { ID, LOGGER_NAME, MESSAGE, LEVEL, PROPERTIES, TIME, THREAD, MARK, CLASS, METHOD, LINE };
+  }
 
   @Override
   public String getKeyStrokeAccelelator() {

--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/parser/JulSimpleFormatterParser.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/parser/JulSimpleFormatterParser.java
@@ -23,7 +23,6 @@ import pl.otros.logview.api.model.LogData;
 import pl.otros.logview.api.parser.MultiLineLogParser;
 import pl.otros.logview.api.parser.ParserDescription;
 import pl.otros.logview.api.parser.ParsingContext;
-import pl.otros.logview.api.parser.TableColumnNameSelfDescribable;
 
 import javax.imageio.ImageIO;
 import javax.swing.*;
@@ -35,7 +34,7 @@ import java.util.Locale;
 import java.util.Properties;
 import java.util.logging.Level;
 
-public class JulSimpleFormatterParser implements MultiLineLogParser, TableColumnNameSelfDescribable {
+public class JulSimpleFormatterParser implements MultiLineLogParser {
 
   private static final String DATE_PATTERNS = "DATE_PATTERNS";
 
@@ -73,6 +72,7 @@ public class JulSimpleFormatterParser implements MultiLineLogParser, TableColumn
     return pd;
   }
 
+  @Override
   public LogData parse(String event, ParsingContext context) throws ParseException {
     if (event == null) {
       return null;

--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/parser/json/JsonLogParser.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/parser/json/JsonLogParser.java
@@ -1,6 +1,7 @@
 package pl.otros.logview.parser.json;
 
 import pl.otros.logview.api.InitializationException;
+import pl.otros.logview.api.TableColumns;
 import pl.otros.logview.api.model.LogData;
 import pl.otros.logview.api.parser.LogParser;
 import pl.otros.logview.api.parser.ParserDescription;
@@ -10,6 +11,21 @@ import pl.otros.logview.pluginable.AbstractPluginableElement;
 import java.text.ParseException;
 import java.util.Optional;
 import java.util.Properties;
+
+import static pl.otros.logview.api.TableColumns.CLASS;
+import static pl.otros.logview.api.TableColumns.FILE;
+import static pl.otros.logview.api.TableColumns.ID;
+import static pl.otros.logview.api.TableColumns.LEVEL;
+import static pl.otros.logview.api.TableColumns.LINE;
+import static pl.otros.logview.api.TableColumns.LOGGER_NAME;
+import static pl.otros.logview.api.TableColumns.MARK;
+import static pl.otros.logview.api.TableColumns.MESSAGE;
+import static pl.otros.logview.api.TableColumns.METHOD;
+import static pl.otros.logview.api.TableColumns.NDC;
+import static pl.otros.logview.api.TableColumns.NOTE;
+import static pl.otros.logview.api.TableColumns.PROPERTIES;
+import static pl.otros.logview.api.TableColumns.THREAD;
+import static pl.otros.logview.api.TableColumns.TIME;
 
 /**
  * Parser of log in json format. It can skip if between json object are some junk (from standard output). From properties
@@ -60,6 +76,10 @@ public class JsonLogParser extends AbstractPluginableElement implements LogParse
     return null;
   }
 
+  @Override
+  public TableColumns[] getTableColumnsToUse() {
+    return new TableColumns[] { ID, LEVEL, TIME, MESSAGE, THREAD, LOGGER_NAME, CLASS, METHOD, LINE, FILE, NOTE, NDC, MARK, PROPERTIES };
+  }
 
   @Override
   public ParserDescription getParserDescription() {

--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/parser/log4j/Log4jPatternIsoDate5pTMNLogParser.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/parser/log4j/Log4jPatternIsoDate5pTMNLogParser.java
@@ -18,6 +18,7 @@ package pl.otros.logview.parser.log4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.otros.logview.api.InitializationException;
+import pl.otros.logview.api.TableColumns;
 import pl.otros.logview.api.model.LogData;
 import pl.otros.logview.api.parser.MultiLineLogParser;
 import pl.otros.logview.api.parser.ParserDescription;
@@ -30,7 +31,12 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Properties;
-import java.util.logging.Level;
+
+import static pl.otros.logview.api.TableColumns.ID;
+import static pl.otros.logview.api.TableColumns.LEVEL;
+import static pl.otros.logview.api.TableColumns.MESSAGE;
+import static pl.otros.logview.api.TableColumns.THREAD;
+import static pl.otros.logview.api.TableColumns.TIME;
 
 public class Log4jPatternIsoDate5pTMNLogParser implements MultiLineLogParser {
 
@@ -120,16 +126,16 @@ public class Log4jPatternIsoDate5pTMNLogParser implements MultiLineLogParser {
 
     String level = sb.substring(24, 30).trim();
     String thread = sb.substring(threadStartIndex + 1, threadEndIndex);
-    logData.setClazz("");
-    logData.setMessage("");
     logData.setThread(thread);
-    logData.setLoggerName("");
     logData.setMessage(sb.substring(threadEndIndex + 1).trim());
-    Level l = Log4jUtil.parseLevel(level);
-    logData.setLevel(l);
+    logData.setLevel(Log4jUtil.parseLevel(level));
     sb.setLength(0);
     return logData;
+  }
 
+  @Override
+  public TableColumns[] getTableColumnsToUse() {
+    return new TableColumns[] { ID, TIME, MESSAGE, THREAD, LEVEL };
   }
 
   @Override

--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/parser/log4j/Log4jPatternMultilineLogParser.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/parser/log4j/Log4jPatternMultilineLogParser.java
@@ -44,7 +44,6 @@ import pl.otros.logview.api.model.LogData;
 import pl.otros.logview.api.parser.MultiLineLogParser;
 import pl.otros.logview.api.parser.ParserDescription;
 import pl.otros.logview.api.parser.ParsingContext;
-import pl.otros.logview.api.parser.TableColumnNameSelfDescribable;
 import pl.otros.logview.parser.CustomLevelsParser;
 
 import java.text.DateFormat;
@@ -138,7 +137,7 @@ import java.util.regex.PatternSyntaxException;
  * @author Code highly based on
  *         http://svn.apache.org/repos/asf/logging/log4j/companions/receivers/trunk/src/main/java/org/apache/log4j/varia/LogFilePatternReceiver.java
  */
-public class Log4jPatternMultilineLogParser implements MultiLineLogParser, TableColumnNameSelfDescribable {
+public class Log4jPatternMultilineLogParser implements MultiLineLogParser {
 
   private static final java.util.logging.Logger LOG = java.util.logging.Logger.getLogger(Log4jPatternMultilineLogParser.class.getName());
 


### PR DESCRIPTION
The marker interface `TableColumnNameSelfDescribable` was missing for `Log4jXmlLogImporter`.
Adding it fixed the problem, but is more a point-fix than a real solution.

I marked both `LogImporter` and `LogParser` as `TableColumnNameSelfDescribable` which resulted in cleaner code and prevents mistakes in the future.