### PR TITLE
#559 fixed cancelled Worker not detect it is cancelled

### DIFF
--- a/OtrosVfsBrowser/src/main/java/pl/otros/vfs/browser/actions/BaseNavigateAction.java
+++ b/OtrosVfsBrowser/src/main/java/pl/otros/vfs/browser/actions/BaseNavigateAction.java
@@ -35,7 +35,7 @@ public abstract class BaseNavigateAction extends AbstractAction {
 
   public VfsBrowser browser;
   private static Executor executor = Executors.newCachedThreadPool();
-  private volatile SwingWorker<Void, Void> showLoadingAfterDelayWorker;
+  private volatile CancelableSwingWorker showLoadingAfterDelayWorker;
   private Component focusOwner;
 
   public BaseNavigateAction(VfsBrowser browser) {
@@ -118,11 +118,11 @@ public abstract class BaseNavigateAction extends AbstractAction {
 
     focusOwner = KeyboardFocusManager.getCurrentKeyboardFocusManager().getFocusOwner();
     cancelScheduledLoading();
-    showLoadingAfterDelayWorker = new SwingWorker<Void, Void>() {
+    showLoadingAfterDelayWorker = new CancelableSwingWorker() {
 
       @Override
       protected void done() {
-        boolean cancelled = isCancelled();
+        boolean cancelled = isCancelledBeforeDoneEnded();
         if (!cancelled) {
           browser.showLoading();
         } else {
@@ -151,7 +151,7 @@ public abstract class BaseNavigateAction extends AbstractAction {
   }
 
   public void cancelScheduledLoading() {
-    Optional.ofNullable(showLoadingAfterDelayWorker).ifPresent(t -> t.cancel(false));
+    Optional.ofNullable(showLoadingAfterDelayWorker).ifPresent(CancelableSwingWorker::doCancel);
   }
 
   public enum CheckBeforeActionResult {

--- a/OtrosVfsBrowser/src/main/java/pl/otros/vfs/browser/actions/CancelableSwingWorker.java
+++ b/OtrosVfsBrowser/src/main/java/pl/otros/vfs/browser/actions/CancelableSwingWorker.java
@@ -1,0 +1,24 @@
+package pl.otros.vfs.browser.actions;
+
+import javax.swing.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * The common SwingWorker is marked as cancelled if you run cancel() while the doInBackground() method is running.
+ * But if the SwingWorker already ended doInBackground() method, but done() method is not started (queued into AWT Thread) and at this moment cancel() will be executed
+ * the isCancelled() method return false.
+ * <br>
+ * The isCancelledBeforeDoneEnded() method returns independently true if the Worker canceled before doInBackground() or after.
+ */
+public abstract class CancelableSwingWorker extends SwingWorker<Void, Void> {
+  private final AtomicBoolean cancel = new AtomicBoolean(false);
+
+  public void doCancel() {
+    this.cancel.set(true);
+    super.cancel(false);
+  }
+
+  public boolean isCancelledBeforeDoneEnded() {
+    return cancel.get();
+  }
+}

--- a/OtrosVfsBrowser/src/main/java/pl/otros/vfs/browser/actions/CancelableSwingWorker.java
+++ b/OtrosVfsBrowser/src/main/java/pl/otros/vfs/browser/actions/CancelableSwingWorker.java
@@ -1,7 +1,6 @@
 package pl.otros.vfs.browser.actions;
 
 import javax.swing.*;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * The common SwingWorker is marked as cancelled if you run cancel() while the doInBackground() method is running.
@@ -11,14 +10,14 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * The isCancelledBeforeDoneEnded() method returns independently true if the Worker canceled before doInBackground() or after.
  */
 public abstract class CancelableSwingWorker extends SwingWorker<Void, Void> {
-  private final AtomicBoolean cancel = new AtomicBoolean(false);
+  private boolean cancel = false;
 
   public void doCancel() {
-    this.cancel.set(true);
+    this.cancel = true;
     super.cancel(false);
   }
 
   public boolean isCancelledBeforeDoneEnded() {
-    return cancel.get();
+    return cancel;
   }
 }


### PR DESCRIPTION
The common SwingWorker is marked as cancelled if you run cancel() while the doInBackground() method is running. But if the SwingWorker already ended doInBackground() method, but done() method is not started (queued into AWT Thread) and at this moment cancel() will be executed the isCancelled() method return false.