### PR TITLE
Fix to display the column "Logger" if autodetected 

### DIFF
--- a/OtrosLogViewer-app/src/main/java/pl/otros/logview/parser/log4j/Log4jPatternMultilineLogParser.java
+++ b/OtrosLogViewer-app/src/main/java/pl/otros/logview/parser/log4j/Log4jPatternMultilineLogParser.java
@@ -842,6 +842,9 @@ public class Log4jPatternMultilineLogParser implements MultiLineLogParser {
     if (matchingKeywords.contains(Log4jPatternMultilineLogParser.NDC))
       list.add(TableColumns.NDC);
 
+    if (matchingKeywords.contains(Log4jPatternMultilineLogParser.LOGGER))
+      list.add(TableColumns.LOGGER_NAME);
+
     if (!keywords.containsAll(matchingKeywords))
       list.add(TableColumns.PROPERTIES);
 


### PR DESCRIPTION
The Log4jPatternMultilineLogParser detect it in Logfile all columns to display in Table. The Logger Column was forgotten.