### PR TITLE
#602 load versionInfo.json from release page to check version

### DIFF
--- a/buildSrc/src/main/java/olv.java-conventions.gradle
+++ b/buildSrc/src/main/java/olv.java-conventions.gradle
@@ -67,6 +67,7 @@ dependencies {
     implementation 'org.scala-lang:scala-library:2.12.4'
     implementation 'org.scala-lang.modules:scala-parser-combinators_2.12:1.1.0'
     implementation 'io.dropwizard.metrics:metrics-core:3.2.2'
+    implementation 'com.alibaba:fastjson:1.2.76'
     testImplementation 'org.testng:testng:6.8.8'
     testImplementation 'org.mockito:mockito-core:1.9.0'
     testImplementation 'org.assertj:assertj-core:3.6.2'

--- a/olv-core/src/main/java/pl/otros/logview/exceptionshandler/errrorreport/OtrosAppERDC.java
+++ b/olv-core/src/main/java/pl/otros/logview/exceptionshandler/errrorreport/OtrosAppERDC.java
@@ -2,7 +2,7 @@ package pl.otros.logview.exceptionshandler.errrorreport;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import pl.otros.logview.VersionUtil;
+import pl.otros.logview.updater.VersionUtil;
 import pl.otros.logview.api.OtrosApplication;
 import pl.otros.logview.api.pluginable.AllPluginables;
 import pl.otros.logview.api.pluginable.PluginableElement;

--- a/olv-core/src/main/java/pl/otros/logview/gui/LogViewMainFrame.java
+++ b/olv-core/src/main/java/pl/otros/logview/gui/LogViewMainFrame.java
@@ -28,7 +28,7 @@ import org.apache.commons.lang.StringUtils;
 import org.pushingpixels.substance.api.skin.SubstanceBusinessBlackSteelLookAndFeel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import pl.otros.logview.VersionUtil;
+import pl.otros.logview.updater.VersionUtil;
 import pl.otros.logview.api.ConfKeys;
 import pl.otros.logview.api.Ide;
 import pl.otros.logview.api.InitializationException;

--- a/olv-core/src/main/java/pl/otros/logview/gui/OtrosSplash.java
+++ b/olv-core/src/main/java/pl/otros/logview/gui/OtrosSplash.java
@@ -15,7 +15,7 @@
  ******************************************************************************/
 package pl.otros.logview.gui;
 
-import pl.otros.logview.VersionUtil;
+import pl.otros.logview.updater.VersionUtil;
 import pl.otros.logview.api.StatusObserver;
 
 import java.awt.*;

--- a/olv-core/src/main/java/pl/otros/logview/gui/actions/AboutAction.java
+++ b/olv-core/src/main/java/pl/otros/logview/gui/actions/AboutAction.java
@@ -17,7 +17,7 @@ package pl.otros.logview.gui.actions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import pl.otros.logview.VersionUtil;
+import pl.otros.logview.updater.VersionUtil;
 import pl.otros.logview.api.OtrosApplication;
 import pl.otros.logview.api.gui.Icons;
 import pl.otros.logview.api.gui.OtrosAction;

--- a/olv-core/src/main/java/pl/otros/logview/gui/actions/CheckForNewVersionAbstract.java
+++ b/olv-core/src/main/java/pl/otros/logview/gui/actions/CheckForNewVersionAbstract.java
@@ -19,12 +19,13 @@ import org.apache.commons.configuration.DataConfiguration;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import pl.otros.logview.VersionUtil;
 import pl.otros.logview.api.OtrosApplication;
 import pl.otros.logview.api.gui.OtrosAction;
+import pl.otros.logview.updater.VersionUtil;
 
 import javax.swing.*;
 import java.awt.event.ActionEvent;
+import java.io.FileNotFoundException;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.Optional;
@@ -32,8 +33,8 @@ import java.util.Optional;
 import static pl.otros.logview.api.ConfKeys.*;
 
 public abstract class CheckForNewVersionAbstract extends OtrosAction {
-  private static final Logger LOGGER = LoggerFactory.getLogger(CheckForNewVersionAction.class.getName());
-  private VersionUtil versionUtil = new VersionUtil();
+  private static final Logger LOGGER = LoggerFactory.getLogger(CheckForNewVersionAbstract.class.getName());
+  private final VersionUtil versionUtil = new VersionUtil();
 
   private SwingWorker<Optional<String>, Void> versionChecker = new SwingWorker<Optional<String>, Void>() {
     @Override
@@ -49,9 +50,10 @@ public abstract class CheckForNewVersionAbstract extends OtrosAction {
         proxy = new Proxy(proxyType, proxySocketAddress);
       }
       try {
-        LOGGER.info("Checking current and running versionss");
-        running = versionUtil.getRunningVersion();
-        current = versionUtil.getCurrentVersion(running, proxy, getOtrosApplication());
+        LOGGER.info("Checking current and running versions");
+        current = versionUtil.getCurrentVersion(proxy);
+      } catch (FileNotFoundException e) {
+        LOGGER.error("No version Info added to release page! Cannot check version.");
       } catch (Exception e) {
         LOGGER.error("Error checking version: " + e.getMessage());
       }

--- a/olv-core/src/main/java/pl/otros/logview/gui/actions/CheckForNewVersionAction.java
+++ b/olv-core/src/main/java/pl/otros/logview/gui/actions/CheckForNewVersionAction.java
@@ -27,6 +27,7 @@ import java.net.URI;
 public class CheckForNewVersionAction extends CheckForNewVersionAbstract {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CheckForNewVersionAction.class.getName());
+  public static final String LATEST_RELEASE_DOWNLOAD_URL = "https://github.com/otros-systems/otroslogviewer/releases/latest";
 
   public CheckForNewVersionAction(OtrosApplication otrosApplication) {
     super(otrosApplication);
@@ -37,10 +38,10 @@ public class CheckForNewVersionAction extends CheckForNewVersionAbstract {
   protected void handleError(Exception e) {
     String message = "Problem with checking new version: " + e.getLocalizedMessage();
     JOptionPane.showMessageDialog(null, message, "Error!", JOptionPane.ERROR_MESSAGE);
-    LOGGER.warn("Error when checking new version" + e.getMessage());
+    LOGGER.warn("Error when checking new version " + e.getMessage());
     StatusObserver statusObserver = getOtrosApplication().getStatusObserver();
     if (statusObserver != null) {
-      statusObserver.updateStatus("Error when checking new version" + e.getMessage(), StatusObserver.LEVEL_WARNING);
+      statusObserver.updateStatus("Error when checking new version " + e.getMessage(), StatusObserver.LEVEL_WARNING);
     }
   }
 
@@ -53,17 +54,25 @@ public class CheckForNewVersionAction extends CheckForNewVersionAbstract {
     Object message;
     JPanel panel = new JPanel(new GridLayout(2, 1));
     panel.add(new JLabel("Your version is " + running + ", current version is " + current));
-    JButton button = new JButton("Open download page");
-    button.addActionListener(e -> {
-      try {
-        Desktop.getDesktop().browse(new URI("https://sourceforge.net/projects/otroslogviewer/files/"));
-      } catch (Exception e1) {
-        String msg = "Can't open browser with download page: " + e1.getMessage();
-        LOGGER.error(msg);
-        getOtrosApplication().getStatusObserver().updateStatus(msg, StatusObserver.LEVEL_ERROR);
-      }
-    });
-    panel.add(button);
+    //Only Windows-Java support open URL by browser
+    if (java.awt.Desktop.isDesktopSupported() && java.awt.Desktop.getDesktop().isSupported(java.awt.Desktop.Action.BROWSE)) {
+      JButton button = new JButton("Open download page");
+      button.addActionListener(e -> {
+        try {
+          Desktop.getDesktop().browse(new URI(LATEST_RELEASE_DOWNLOAD_URL));
+        } catch (Exception e1) {
+          String msg = "Can't open browser with download page: " + e1.getMessage();
+          LOGGER.error(msg, e1);
+          getOtrosApplication().getStatusObserver().updateStatus(msg, StatusObserver.LEVEL_ERROR);
+        }
+      });
+      panel.add(button);
+    } else {
+      JTextField link = new JTextField(LATEST_RELEASE_DOWNLOAD_URL);
+      link.setEditable(false);
+      link.setBorder(null);
+      panel.add(link);
+    }
     message = panel;
     JOptionPane.showMessageDialog(null, message);
   }

--- a/olv-core/src/main/java/pl/otros/logview/updater/VersionBean.java
+++ b/olv-core/src/main/java/pl/otros/logview/updater/VersionBean.java
@@ -1,0 +1,42 @@
+package pl.otros.logview.updater;
+
+import com.alibaba.fastjson.annotation.JSONField;
+
+public class VersionBean {
+
+  @JSONField(name = "major")
+  private String major;
+  @JSONField(name = "minor")
+  private String minor;
+  @JSONField(name = "patch")
+  private String patch;
+
+  public String getMajor() {
+    return major;
+  }
+
+  public void setMajor(String major) {
+    this.major = major;
+  }
+
+  public String getMinor() {
+    return minor;
+  }
+
+  public void setMinor(String minor) {
+    this.minor = minor;
+  }
+
+  public String getPatch() {
+    return patch;
+  }
+
+  public void setPatch(String patch) {
+    this.patch = patch;
+  }
+
+  @Override
+  public String toString() {
+    return major + "." + minor + "." + patch;
+  }
+}

--- a/olv-core/src/main/java/pl/otros/logview/updater/VersionInformationBean.java
+++ b/olv-core/src/main/java/pl/otros/logview/updater/VersionInformationBean.java
@@ -1,0 +1,13 @@
+package pl.otros.logview.updater;
+
+public class VersionInformationBean {
+  private VersionBean currentVersion;
+
+  public VersionBean getCurrentVersion() {
+    return currentVersion;
+  }
+
+  public void setCurrentVersion(VersionBean currentVersion) {
+    this.currentVersion = currentVersion;
+  }
+}


### PR DESCRIPTION
Make a simple fix to show when updates available. All you need is to release also a versionInfo.json. This is not very nice, but simple to implement. In a next step we can use a github api.