### PR TITLE
Fix: File handles are now closed properly when closing a tab

### DIFF
--- a/olv-core/src/main/java/pl/otros/logview/gui/actions/TailLogActionListener.java
+++ b/olv-core/src/main/java/pl/otros/logview/gui/actions/TailLogActionListener.java
@@ -112,7 +112,10 @@ public class TailLogActionListener extends OtrosAction {
       3000,
       Optional.of(2000L)
     );
-    panel.onClose(()->logLoader.close(session));
+    panel.onClose(()-> {
+      logLoader.close(session);
+      loadingInfo.close();
+    });
     SwingUtilities.invokeLater(panel::switchToContentView);
   }
 


### PR DESCRIPTION
See issue #536

As mentioned in the issue, i'm not familiar with the code, so for example it might be possible to call `loadingInfo.close()` directly in `TailLogActionListener.openFileObjectInTailMode()` without waiting for the tab to close, but i simply don't know.